### PR TITLE
Improve homepage article card layout

### DIFF
--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -25,7 +25,7 @@
 .home-bento-card:hover { transform:translateY(-2px); border-color:color-mix(in srgb,var(--accent) 38%,var(--line)); }
 .home-bento-card:first-child { grid-row:span 2; min-height:558px; padding:32px; background:linear-gradient(180deg,color-mix(in srgb,var(--surface) 86%,var(--accent) 14%),var(--surface-2)); }
 .home-bento-card:nth-child(4) { background:color-mix(in srgb,var(--surface) 94%,var(--accent) 6%); }
-.home-bento-card h3 { margin:auto 0 12px; font-family:var(--font-heading,var(--font-sans)); font-size:clamp(28px,2.7vw,36px); font-weight:var(--heading-weight,800); line-height:1.02; letter-spacing:-.04em; text-wrap:balance; text-transform:var(--heading-transform,none); }
+.home-bento-card h3 { margin:16px 0 12px; font-family:var(--font-heading,var(--font-sans)); font-size:clamp(28px,2.7vw,36px); font-weight:var(--heading-weight,800); line-height:1.02; letter-spacing:-.04em; text-wrap:balance; text-transform:var(--heading-transform,none); }
 .home-bento-card:first-child h3 { max-width:450px; font-size:clamp(40px,4.4vw,54px); }
 .home-bento-card h3 a { text-decoration:none; }
 .home-bento-card h3 a:hover,.home-bento-card h3 a:focus-visible { color:var(--accent); }

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@ stylesheet: /assets/css/home.css
       <h2 id="featured-heading"><a href="{{ primary.url | relative_url }}">{{ primary.title }}</a></h2>
       {% if primary.description %}<p>{{ primary.description | truncate: 190 }}</p>{% endif %}
       <div class="home-prototype-meta">
-        {{ primary.date | date: "%b %-d %Y" }}
+        {{ primary.date | date: "%B %-d, %Y" }}
         {% if primary.tags and primary.tags.size > 0 %} · {{ primary.tags | join: " · " }}{% endif %}
       </div>
     </div>
@@ -66,10 +66,16 @@ stylesheet: /assets/css/home.css
       {% if card_count < 5 and post.url != primary.url %}
         <article class="home-bento-card">
           <div class="home-bento-card__meta">
-            {% if post.tags and post.tags.size > 0 %}{{ post.tags | first }} · {% endif %}{{ post.date | date: "%Y" }}
+            {% if post.tags and post.tags.size > 0 %}{{ post.tags | first }} · {% endif %}{{ post.date | date: "%B %-d, %Y" }}
           </div>
           <h3><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h3>
-          {% if post.description %}<p>{{ post.description | truncate: 150 }}</p>{% endif %}
+          {% if post.description %}
+            {% if card_count == 0 %}
+              <p>{{ post.description | truncate: 280 }}</p>
+            {% else %}
+              <p>{{ post.description | truncate: 150 }}</p>
+            {% endif %}
+          {% endif %}
         </article>
         {% assign card_count = card_count | plus: 1 %}
       {% endif %}


### PR DESCRIPTION
## Summary
- show full publication dates on homepage article cards and the featured article
- top-align bento card content instead of pushing titles to the bottom
- allow the tall first bento card to use a longer excerpt

## Notes
The first bento card still spans two rows; this change keeps the intended visual hierarchy while making better use of the available space.